### PR TITLE
Add option to serve metrics via http

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,16 @@ If the directory is not already present, it will be created by the exporter.
 The command `pkg_exporter` provided by the package or the binary shall be executed in a appropriate interval, e.g. using cron or systemd timers.
 The exporter needs to be executed with appropriate privileges, which are not necessarily root privileges.
 
+Several command line options can be used along with the `pkg_exporter` command, which are as follows:
+| Option | Description |
+| ------- | --------- | 
+| -f, --exporter-file | The file where prometheus metrics are exported, default is `/var/prometheus/pkg-exporter.prom` |
+| -d, --daemon | Run as daemon and serve metrics via http. |
+| -a, --bind-addr | The address to serve metrics via http. Default is `0.0.0.0` |
+| -p, --port | The port to serve metrics via http. Default is `8089` | 
+| -r, --rootdir | Custom root directory for dpkg, if any. |
+| -t, --time-wait | Time, in seconds, to wait between metrics updates. Default is 300 |
+
 An example configuration will be provided in this repository in the future.
 
 ### apt hook

--- a/src/pkg_exporter/pkgmanager/apt.py
+++ b/src/pkg_exporter/pkgmanager/apt.py
@@ -3,6 +3,7 @@ import apt
 import apt.progress
 from pathlib import Path
 
+
 class AptPkgManager:
     def __init__(self, rootdir=None):
         self.rootdir = rootdir

--- a/src/pkg_exporter/pkgmanager/apt.py
+++ b/src/pkg_exporter/pkgmanager/apt.py
@@ -3,9 +3,10 @@ import apt
 import apt.progress
 from pathlib import Path
 
-
 class AptPkgManager:
-    def __init__(self):
+    def __init__(self, rootdir=None):
+        self.rootdir = rootdir
+
         self.metricDict = {}
         self.metricDict["installed"] = {"description": "Installed packages per origin"}
         self.metricDict["upgradable"] = {
@@ -21,7 +22,7 @@ class AptPkgManager:
         self.metaMetrics["update_start_time"] = 0
         self.metaMetrics["update_end_time"] = 0
 
-        self.cache = apt.Cache()
+        self.cache = apt.Cache(rootdir=self.rootdir)
         self.cache.open(None)
 
     def labelValues(self, origin):

--- a/src/pkg_exporter/textfile.py
+++ b/src/pkg_exporter/textfile.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 from prometheus_client import Gauge, write_to_textfile, start_http_server
-from prometheus_client import GC_COLLECTOR, PLATFORM_COLLECTOR, PROCESS_COLLECTOR
+from prometheus_client import GC_COLLECTOR, PLATFORM_COLLECTOR, PROCESS_COLLECTOR   # noqa E501
 from prometheus_client.core import REGISTRY
 from time import sleep
 from pkg_exporter.pkgmanager import apt
@@ -22,14 +22,19 @@ def populate_registry(rootdir=None):
 
     # also add reboot metrics
     rebootmanager = reboot.RebootManager()
-    reboot_gauge = REGISTRY._names_to_collectors.get("pkg_reboot_required", None)
+    reboot_gauge = REGISTRY._names_to_collectors.get(
+        "pkg_reboot_required", None)
     if not reboot_gauge:
-        reboot_gauge = Gauge("pkg_reboot_required", "Node Requires an Reboot", [])
+        reboot_gauge = Gauge(
+            "pkg_reboot_required",
+            "Node Requires an Reboot",
+            [])
 
     # add update statistics
     meta_metric = pkgmanager.getMetaMetricDict()
     for key, value in meta_metric.items():
-        meta_gauges[key] = REGISTRY._names_to_collectors.get(f"pkg_{key}", None)
+        meta_gauges[key] = REGISTRY._names_to_collectors.get(
+            f"pkg_{key}", None)
         if not meta_gauges[key]:
             meta_gauges[key] = Gauge(f"pkg_{key}", value["description"])
 
@@ -83,7 +88,9 @@ def processArgs():
         "-f",
         "--exporter-file",
         type=str,
-        default=os.getenv("PKG_EXPORTER_FILE", "/var/prometheus/pkg-exporter.prom"),
+        default=os.getenv(
+            "PKG_EXPORTER_FILE",
+            "/var/prometheus/pkg-exporter.prom"),
         help="File to export, if used the content will not be served",
     )
     group.add_argument(

--- a/src/pkg_exporter/textfile.py
+++ b/src/pkg_exporter/textfile.py
@@ -1,16 +1,16 @@
 #!/usr/bin/env python3
 
-from prometheus_client import CollectorRegistry, Gauge, write_to_textfile
+from prometheus_client import CollectorRegistry, Gauge, write_to_textfile, start_http_server
+from time import sleep
 from pkg_exporter.pkgmanager import apt
 from pkg_exporter import reboot
+import argparse
 import os
+import sys
 
-
-def main():
-    registry = CollectorRegistry()
-
+def populate_registry(registry, rootdir=None):
     # get updates from apt
-    pkgmanager = apt.AptPkgManager()
+    pkgmanager = apt.AptPkgManager(rootdir=rootdir)
 
     # initially, check which metrics and labels are available
     metrics = pkgmanager.getMetricDict()
@@ -50,12 +50,64 @@ def main():
     rebootmanager.query()
     reboot_gauge.set(rebootmanager.getMetricValue())
 
-    exporter_file = os.getenv("PKG_EXPORTER_FILE", "/var/prometheus/pkg-exporter.prom")
+def write_registry_to_file(registry, exporter_file=None):
+    if not exporter_file:
+        exporter_file = os.getenv("PKG_EXPORTER_FILE",
+                                  "/var/prometheus/pkg-exporter.prom")
     exporter_dir = os.path.dirname(exporter_file)
     os.makedirs(exporter_dir, exist_ok=True)
 
     write_to_textfile(exporter_file, registry)
 
+def serve(registry, addr, port, timewait, rootdir):
+    start_http_server(addr=addr, port=port, registry=registry)
+    while True:
+        sleep(timewait)
+        registry = CollectorRegistry()
+        populate_registry(registry, rootdir)
+
+
+def processArgs():
+    parser = argparse.ArgumentParser(
+        description="Collect metrics from apt and export it as a service")
+    group = parser.add_mutually_exclusive_group()
+
+    group.add_argument("-f", "--exporter-file",
+        type=str,
+        default=os.getenv('PKG_EXPORTER_FILE', "/var/prometheus/pkg-exporter.prom"),
+        help="File to export, if used the content will not be served")
+    group.add_argument("-d", "--daemon",
+        action='store_true',
+        help="Run as daemon and server metric via http")
+    parser.add_argument("-a", "--bind-addr",
+        type=str,
+        default=os.getenv('PKG_EXPORTER_ADDR', '0.0.0.0'),
+        help="Bind address")
+    parser.add_argument("-p", "--port",
+        type=int,
+        default=os.getenv('PKG_EXPORTER_PORT', 8089),
+        help="Bind port")
+    parser.add_argument("-r", "--rootdir",
+        type=str,
+        default=os.getenv('PKG_EXPORTER_ROOT_DIR', None),
+        help="Custom root directory for dpkg")
+    parser.add_argument("-t", "--time-wait",
+        type=int,
+        default=os.getenv('PKG_EXPORTER_TIME_WAIT', 300),
+        help="time (in second) to wait between data updates")
+    return parser.parse_args()
+
+def main():
+    args = processArgs()
+    registry = CollectorRegistry()
+    populate_registry(registry, args.rootdir)
+
+    if not args.daemon:
+        write_registry_to_file(registry, args.exporter_file)
+    else:
+        serve(registry, args.bind_addr, args.port, args.time_wait, args.rootdir)
+
 
 if __name__ == "__main__":
     main()
+


### PR DESCRIPTION
A `-d` flag can be used with the `pkg-exporter` command to serve metrics via HTTP. We also added a few other flags that can be used to modify the default behavior of the exporter. 